### PR TITLE
Fix curly braces

### DIFF
--- a/janus.doc
+++ b/janus.doc
@@ -152,8 +152,8 @@ py_set(List) & $\Longleftrightarrow$ & Set & \\
 -()     & $\Longleftrightarrow$ & ()  & Python empty Tuple \\
 -(a,b,\ldots) & $\Longleftrightarrow$ & (a,b,\ldots) & Python Tuples.  Note that a Prolog \jargon{pair} \exam{A-B} maps to a Python (binary) tuple. \\
 Dict    & $\Longleftrightarrow$ & Dict     & Default for SWI-Prolog \\
-\{k:v,\ldots\} & $\Longleftrightarrow$ & Dict & Compatibility when using \exam{py_dict_as({{}})}\\
-py(\{\mbox{}\}) & $\longleftarrow$ & \{\mbox{}\} & Empty dict when using \exam{py_dict_as({{}})}\\
+\{k:v,\ldots\} & $\Longleftrightarrow$ & Dict & Compatibility when using \exam{py_dict_as(\Scurl)}\\
+py(\{\mbox{}\}) & $\longleftarrow$ & \{\mbox{}\} & Empty dict when using \exam{py_dict_as(\Scurl)}\\
 \{k:v,\ldots\} & $\longrightarrow$ & Dict    & Compatibility (see above) \\
 py(\{k:v,\ldots\}) & $\longrightarrow$ & Dict & Compatibility (see above) \\
 eval(Term) & $\longrightarrow$ & Object & Evaluate Term as first argument of py_call/2 \\


### PR DESCRIPTION
This showed up when I was changing `doc2tex.pl` to parse additional C/C++ function calls. Following is the crash I got (but why didn't the `catch_with_backtrace/3` produce a backtrace?)
```
cd /home/peter/src/swipl-devel/build/packages/swipy && /home/peter/src/swipl-devel/build/src/swipl -f none --no-packs /home/peter/src/swipl-devel/build/home/library/ext/ltx2htm/latex2html.pl -- --quiet janus && /usr/bin/cmake -E remove /home/peter/src/swipl-devel/build/home/doc/manindex.db
ERROR: put_html_token/1: instantiation error
   Redo: (1,353) tex:write_html(nospace([])) ? 20g
  [1,353] tex:write_html(nospace([]))
  [1,352] tex:write_html([nospace([])])
  [1,351] tex:write_html([[nospace([])], nospace(')')])
  [1,349] tex:write_html([[nospace('('), [nospace([])], nospace(')')]])
  [1,347] tex:write_html([[py_dict_as, [nospace('('), [nospace([])], nospace(')')]], html('</b>')])
  [1,344] tex:write_html([lref(func, 'py_dict_as()', [py_dict_as, [nospace('('), [nospace(...)], nospace(...)]]), html('</code>'), html('</td>'), html('</tr>'), html('<tr>'), html('<td>'), lref(..., ..., ...)|...])
     [16] tex:run_latex2html('/home/peter/src/swipl-devel/build/packages/swipy/janus.tex')
     [15] tex:latex2html(janus, [quiet(true)])
     [12] catch_with_backtrace('<garbage_collected>', '<garbage_collected>', '<garbage_collected>')
     [11] tex:main('<garbage_collected>')
      [9] catch_with_backtrace('<garbage_collected>', '<garbage_collected>', '<garbage_collected>')
      [8] prolog_main:main
      [5] run_init_goal('<garbage_collected>', @(tex:main, '/home/peter/src/swipl-devel/build/home/library/ext/ltx2htm/latex2html.pl':3227))
```