### PR TITLE
Fix idobj refcount in py_register_module

### DIFF
--- a/janus/janus.c
+++ b/janus/janus.c
@@ -426,7 +426,6 @@ py_register_module(term_t name, term_t options, PyObject **mod, int flags)
       goto out;
 
     m = check_error(PyImport_Import(idobj));
-    Py_DECREF(idobj);
     if ( m )
     { PyObject *old = NULL;
       if ( mod )
@@ -434,12 +433,11 @@ py_register_module(term_t name, term_t options, PyObject **mod, int flags)
       rc = py_add_hashmap(py_module_table, as, m, &old);
       if ( old )
 	Py_DECREF(old);
-      return rc;
     }
+out:
+    Py_DECREF(idobj);
   }
 
-out:
-  Py_CLEAR(idobj);
   return rc;
 }
 


### PR DESCRIPTION
I am trying to build swipl 9.2.3 for the Fedora Linux distribution.  I am seeing intermittent segfaults in the `swipy:xsb_janus` test.  Valgrind shows a use-after-free:
```
$ valgrind --leak-check=no --enable-debuginfod=yes --read-inline-info=yes --read-var-info=yes ../../src/swipl -p foreign=:/builddir/build/BUILD/swipl-9.2.3/redhat-linux-build/packages/plunit -f none --no-packs --on-error=status -s /builddir/build/BUILD/swipl-9.2.3/packages/swipy/test_xsb_janus.pl -g test_xsb_janus -t halt
==185== Memcheck, a memory error detector
==185== Copyright (C) 2002-2022, and GNU GPL'd, by Julian Seward et al.
==185== Using Valgrind-3.22.0 and LibVEX; rerun with -h for copyright info
==185== Command: ../../src/swipl -p foreign=:/builddir/build/BUILD/swipl-9.2.3/redhat-linux-build/packages/plunit -f none --no-packs --on-error=status -s /builddir/build/BUILD/swipl-9.2.3/packages/swipy/test_xsb_janus.pl -g test_xsb_janus -t halt
==185== 
[17/20] xsb_janus:error ..$<3>==185== Invalid read of size 8
==185==    at 0x6078664: UnknownInlinedFun (object.h:220)
==185==    by 0x6078664: UnknownInlinedFun (pycore_object.h:330)
==185==    by 0x6078664: visit_decref (gcmodule.c:465)
==185==    by 0x5FB6486: ImportError_traverse.cold (exceptions.c:1591)
==185==    by 0x6078393: subtract_refs (gcmodule.c:491)
==185==    by 0x6077689: UnknownInlinedFun (gcmodule.c:1116)
==185==    by 0x6077689: gc_collect_main (gcmodule.c:1242)
==185==    by 0x61031AA: gc_collect_with_callback (gcmodule.c:1426)
==185==    by 0x6102FE9: UnknownInlinedFun (gcmodule.c:2292)
==185==    by 0x6102FE9: _Py_HandlePending (ceval_gil.c:1045)
==185==    by 0x6072C63: _PyEval_EvalFrameDefault (ceval.c:834)
==185==    by 0x6101FAA: PyEval_EvalCode (ceval.c:578)
==185==    by 0x611CD16: UnknownInlinedFun (bltinmodule.c:1096)
==185==    by 0x611CD16: builtin_exec (bltinmodule.c.h:586)
==185==    by 0x6080497: cfunction_vectorcall_FASTCALL_KEYWORDS (methodobject.c:438)
==185==    by 0x606D4F8: UnknownInlinedFun (call.c:387)
==185==    by 0x606D4F8: _PyEval_EvalFrameDefault (bytecodes.c:3254)
==185==    by 0x608834A: UnknownInlinedFun (pycore_call.h:92)
==185==    by 0x608834A: object_vacall (call.c:850)
==185==  Address 0x7494608 is 8 bytes inside a block of size 50 free'd
==185==    at 0x4845B2C: free (vg_replace_malloc.c:985)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:73)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:685)
==185==    by 0x6051CAC: _PyObject_Free (obmalloc.c:1853)
==185==    by 0x56B0FCE: UnknownInlinedFun (object.h:706)
==185==    by 0x56B0FCE: py_register_module (janus.c:442)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4948D10: pl_with_mutex (pl-mutex.c:761)
==185==  Block was alloc'd at
==185==    at 0x484280F: malloc (vg_replace_malloc.c:442)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:45)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:662)
==185==    by 0x604DB96: _PyObject_Malloc (obmalloc.c:1569)
==185==    by 0x6054E0C: UnknownInlinedFun (obmalloc.c:801)
==185==    by 0x6054E0C: PyUnicode_New (unicodeobject.c:1251)
==185==    by 0x60541D9: unicode_decode_utf8 (unicodeobject.c:4693)
==185==    by 0x56B0F38: UnknownInlinedFun (janus.c:383)
==185==    by 0x56B0F38: py_register_module (janus.c:409)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185== 
==185== Invalid read of size 8
==185==    at 0x607CD84: UnknownInlinedFun (object.h:220)
==185==    by 0x607CD84: UnknownInlinedFun (pycore_object.h:330)
==185==    by 0x607CD84: visit_reachable (gcmodule.c:501)
==185==    by 0x5FB6486: ImportError_traverse.cold (exceptions.c:1591)
==185==    by 0x607CD03: move_unreachable (gcmodule.c:602)
==185==    by 0x60776A3: UnknownInlinedFun (gcmodule.c:1154)
==185==    by 0x60776A3: gc_collect_main (gcmodule.c:1242)
==185==    by 0x61031AA: gc_collect_with_callback (gcmodule.c:1426)
==185==    by 0x6102FE9: UnknownInlinedFun (gcmodule.c:2292)
==185==    by 0x6102FE9: _Py_HandlePending (ceval_gil.c:1045)
==185==    by 0x6072C63: _PyEval_EvalFrameDefault (ceval.c:834)
==185==    by 0x6101FAA: PyEval_EvalCode (ceval.c:578)
==185==    by 0x611CD16: UnknownInlinedFun (bltinmodule.c:1096)
==185==    by 0x611CD16: builtin_exec (bltinmodule.c.h:586)
==185==    by 0x6080497: cfunction_vectorcall_FASTCALL_KEYWORDS (methodobject.c:438)
==185==    by 0x606D4F8: UnknownInlinedFun (call.c:387)
==185==    by 0x606D4F8: _PyEval_EvalFrameDefault (bytecodes.c:3254)
==185==    by 0x608834A: UnknownInlinedFun (pycore_call.h:92)
==185==    by 0x608834A: object_vacall (call.c:850)
==185==  Address 0x7494608 is 8 bytes inside a block of size 50 free'd
==185==    at 0x4845B2C: free (vg_replace_malloc.c:985)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:73)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:685)
==185==    by 0x6051CAC: _PyObject_Free (obmalloc.c:1853)
==185==    by 0x56B0FCE: UnknownInlinedFun (object.h:706)
==185==    by 0x56B0FCE: py_register_module (janus.c:442)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4948D10: pl_with_mutex (pl-mutex.c:761)
==185==  Block was alloc'd at
==185==    at 0x484280F: malloc (vg_replace_malloc.c:442)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:45)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:662)
==185==    by 0x604DB96: _PyObject_Malloc (obmalloc.c:1569)
==185==    by 0x6054E0C: UnknownInlinedFun (obmalloc.c:801)
==185==    by 0x6054E0C: PyUnicode_New (unicodeobject.c:1251)
==185==    by 0x60541D9: unicode_decode_utf8 (unicodeobject.c:4693)
==185==    by 0x56B0F38: UnknownInlinedFun (janus.c:383)
==185==    by 0x56B0F38: py_register_module (janus.c:409)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185== 
[20/20] xsb_janus:gc ..$<3>==185== Invalid read of size 8
==185==    at 0x6078664: UnknownInlinedFun (object.h:220)
==185==    by 0x6078664: UnknownInlinedFun (pycore_object.h:330)
==185==    by 0x6078664: visit_decref (gcmodule.c:465)
==185==    by 0x5FB6486: ImportError_traverse.cold (exceptions.c:1591)
==185==    by 0x6078393: subtract_refs (gcmodule.c:491)
==185==    by 0x6077ED4: UnknownInlinedFun (gcmodule.c:1116)
==185==    by 0x6077ED4: gc_collect_main (gcmodule.c:1242)
==185==    by 0x61031AA: gc_collect_with_callback (gcmodule.c:1426)
==185==    by 0x615FC92: UnknownInlinedFun (gcmodule.c:1564)
==185==    by 0x615FC92: gc_collect (gcmodule.c.h:139)
==185==    by 0x6080497: cfunction_vectorcall_FASTCALL_KEYWORDS (methodobject.c:438)
==185==    by 0x60FEE94: _PyObject_VectorcallTstate.lto_priv.3 (pycore_call.h:92)
==185==    by 0x56B3E3E: py_eval (janus.c:1859)
==185==    by 0x56B594A: py_call3 (janus.c:2067)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==  Address 0x7494608 is 8 bytes inside a block of size 50 free'd
==185==    at 0x4845B2C: free (vg_replace_malloc.c:985)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:73)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:685)
==185==    by 0x6051CAC: _PyObject_Free (obmalloc.c:1853)
==185==    by 0x56B0FCE: UnknownInlinedFun (object.h:706)
==185==    by 0x56B0FCE: py_register_module (janus.c:442)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4948D10: pl_with_mutex (pl-mutex.c:761)
==185==  Block was alloc'd at
==185==    at 0x484280F: malloc (vg_replace_malloc.c:442)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:45)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:662)
==185==    by 0x604DB96: _PyObject_Malloc (obmalloc.c:1569)
==185==    by 0x6054E0C: UnknownInlinedFun (obmalloc.c:801)
==185==    by 0x6054E0C: PyUnicode_New (unicodeobject.c:1251)
==185==    by 0x60541D9: unicode_decode_utf8 (unicodeobject.c:4693)
==185==    by 0x56B0F38: UnknownInlinedFun (janus.c:383)
==185==    by 0x56B0F38: py_register_module (janus.c:409)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185== 
==185== Invalid read of size 8
==185==    at 0x607CD84: UnknownInlinedFun (object.h:220)
==185==    by 0x607CD84: UnknownInlinedFun (pycore_object.h:330)
==185==    by 0x607CD84: visit_reachable (gcmodule.c:501)
==185==    by 0x5FB6486: ImportError_traverse.cold (exceptions.c:1591)
==185==    by 0x607CD03: move_unreachable (gcmodule.c:602)
==185==    by 0x6077EEE: UnknownInlinedFun (gcmodule.c:1154)
==185==    by 0x6077EEE: gc_collect_main (gcmodule.c:1242)
==185==    by 0x61031AA: gc_collect_with_callback (gcmodule.c:1426)
==185==    by 0x615FC92: UnknownInlinedFun (gcmodule.c:1564)
==185==    by 0x615FC92: gc_collect (gcmodule.c.h:139)
==185==    by 0x6080497: cfunction_vectorcall_FASTCALL_KEYWORDS (methodobject.c:438)
==185==    by 0x60FEE94: _PyObject_VectorcallTstate.lto_priv.3 (pycore_call.h:92)
==185==    by 0x56B3E3E: py_eval (janus.c:1859)
==185==    by 0x56B594A: py_call3 (janus.c:2067)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==  Address 0x7494608 is 8 bytes inside a block of size 50 free'd
==185==    at 0x4845B2C: free (vg_replace_malloc.c:985)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:73)
==185==    by 0x6051CAC: UnknownInlinedFun (obmalloc.c:685)
==185==    by 0x6051CAC: _PyObject_Free (obmalloc.c:1853)
==185==    by 0x56B0FCE: UnknownInlinedFun (object.h:706)
==185==    by 0x56B0FCE: py_register_module (janus.c:442)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4948D10: pl_with_mutex (pl-mutex.c:761)
==185==  Block was alloc'd at
==185==    at 0x484280F: malloc (vg_replace_malloc.c:442)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:45)
==185==    by 0x604DB96: UnknownInlinedFun (obmalloc.c:662)
==185==    by 0x604DB96: _PyObject_Malloc (obmalloc.c:1569)
==185==    by 0x6054E0C: UnknownInlinedFun (obmalloc.c:801)
==185==    by 0x6054E0C: PyUnicode_New (unicodeobject.c:1251)
==185==    by 0x60541D9: unicode_decode_utf8 (unicodeobject.c:4693)
==185==    by 0x56B0F38: UnknownInlinedFun (janus.c:383)
==185==    by 0x56B0F38: py_register_module (janus.c:409)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:469)
==185==    by 0x56B3A4E: UnknownInlinedFun (janus.c:1673)
==185==    by 0x56B3A4E: py_eval (janus.c:1780)
==185==    by 0x56B3EF7: unchain (janus.c:1893)
==185==    by 0x56B57CA: py_call3 (janus.c:2047)
==185==    by 0x488009B: PL_next_solution___LD (pl-vmi.c:4677)
==185==    by 0x48D52B6: callProlog (pl-pro.c:475)
==185==    by 0x4966361: pl_with_output_to2_va.lto_priv.0 (pl-file.c:1776)
==185==    by 0x487F534: PL_next_solution___LD (pl-vmi.c:4642)
==185== 
............................................................... passed (0.024 sec)
% All 20 tests passed in 1.871 seconds (1.795 cpu)
variadic_print: variadic_print: ==185== 
==185== HEAP SUMMARY:
==185==     in use at exit: 5,249,787 bytes in 56,711 blocks
==185==   total heap usage: 141,627 allocs, 84,916 frees, 20,910,469 bytes allocated
==185== 
==185== For a detailed leak analysis, rerun with: --leak-check=full
==185== 
==185== For lists of detected and suppressed errors, rerun with: -s
==185== ERROR SUMMARY: 16 errors from 4 contexts (suppressed: 0 from 0)
```

Note that this code can pass through both `Py_DECREF(idobj)` and `Py_CLEAR(idobj)`.  This PR rearranges the code slightly so that `Py_DECREF(idobj)` is called exactly once if `get_py_name` returns nonnull, thereby not disturbing any references taken by python core due to the `PyImport_Import` call.  With this change, valgrind no longer reports any errors.
